### PR TITLE
Monsterbook save

### DIFF
--- a/sql/db_database.sql
+++ b/sql/db_database.sql
@@ -15980,7 +15980,8 @@ CREATE TABLE IF NOT EXISTS `medalmaps` (
 CREATE TABLE IF NOT EXISTS `monsterbook` (
   `charid` int(11) unsigned NOT NULL,
   `cardid` int(11) NOT NULL,
-  `level` int(1) DEFAULT '1'
+  `level` int(1) DEFAULT '1',
+  PRIMARY KEY (`charid, `cardid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 CREATE TABLE IF NOT EXISTS `monstercarddata` (


### PR DESCRIPTION
Optimized the save for monster book. Removed the unnecessary DELETE.
Reformatted the string query. The old function was using a char buffer of 400000 chars.
Added 'ON DUPLICATE KEY UPDATE level=VALUES(level)': this requires the primary key of the monsterbook table to be (charid, cardid).

-- add primary key below
ALTER TABLE monsterbook ADD PRIMARY KEY(charid, cardid);
